### PR TITLE
Add grapesjs and new page type

### DIFF
--- a/admin/client/App/screens/Item/components/EditForm.js
+++ b/admin/client/App/screens/Item/components/EditForm.js
@@ -389,7 +389,7 @@ var EditForm = React.createClass({
 			<form ref="editForm" className="EditForm-container">
 				{(this.state.alerts) ? <AlertMessages alerts={this.state.alerts} /> : null}
 				<Grid.Row>
-					<Grid.Col large="three-quarters">
+					<Grid.Col large="100%">
 						<Form layout="horizontal" component="div">
 							{this.renderNameField()}
 							{this.renderKeyOrId()}

--- a/admin/public/styles/custom.css
+++ b/admin/public/styles/custom.css
@@ -1,0 +1,48 @@
+/*
+* @Author: django-wong
+* @Date:   2018-09-29 09:56:38
+* @Last Modified by:   django-wong
+* @Last Modified time: 2018-09-29 09:59:16
+*/
+
+/* Override GrapesJs */
+.gjs-pn-views-container {
+	height: 100%;
+	padding: 42px 0 0;
+	right: 0;
+	width: 250px;
+	overflow: auto;
+	box-shadow: 0 0 5px rgba(0,0,0,0.2);
+}
+
+.gjs-pn-views {
+	border-bottom: 2px solid rgba(0,0,0,0.2);
+	right: 0;
+	width: 250px;
+	z-index: 4;
+}
+
+.gjs-pn-options {
+	right: 250px;
+	top: 0;
+}
+
+.gjs-pn-commands {
+	width: calc(100% - 250px);
+	left: 0;
+	top: 0;
+	box-shadow: 0 0 5px rgba(0,0,0,0.2);
+}
+
+.gjs-cv-canvas {
+	background-color: rgba(0,0,0,0.15);
+	box-sizing: border-box;
+	width: calc(100% - 250px);
+	height: calc(100% - 40px);
+	bottom: 0;
+	overflow: hidden;
+	z-index: 1;
+	position: absolute;
+	left: 0;
+	top: 40px;
+}

--- a/admin/public/styles/keystone.less
+++ b/admin/public/styles/keystone.less
@@ -224,3 +224,4 @@
 
 // CUSTOM ADMIN APPLICATION STYLES
 @import (optional) "@{customStylesPath}";
+@import (inline) "./custom.css";

--- a/admin/public/styles/keystone.less
+++ b/admin/public/styles/keystone.less
@@ -12,6 +12,7 @@
 // ------------------------------
 
 @import "@{elementalPath}/less/elemental.less";
+@import (inline) "@{grapesPath}/dist/css/grapes.min.css";
 
 
 // KEYSTONE VARIABLES

--- a/admin/server/app/createStaticRouter.js
+++ b/admin/server/app/createStaticRouter.js
@@ -70,6 +70,7 @@ module.exports = function createStaticRouter (keystone) {
 	var elementalPath = path.join(path.dirname(require.resolve('elemental')), '..');
 	var reactSelectPath = path.join(path.dirname(require.resolve('react-select')), '..');
 	var customStylesPath = keystone.getPath('adminui custom styles') || '';
+	var grapesPath = path.resolve(path.dirname(require.resolve('grapesjs')), '..');
 
 	var lessOptions = {
 		render: {
@@ -77,6 +78,7 @@ module.exports = function createStaticRouter (keystone) {
 				elementalPath: JSON.stringify(elementalPath),
 				reactSelectPath: JSON.stringify(reactSelectPath),
 				customStylesPath: JSON.stringify(customStylesPath),
+				grapesPath: JSON.stringify(grapesPath),
 				adminPath: JSON.stringify(keystone.get('admin path')),
 			},
 		},
@@ -89,6 +91,7 @@ module.exports = function createStaticRouter (keystone) {
 	router.get('/js/signin.js', bundles.signin.serve);
 	router.get('/js/admin.js', bundles.admin.serve);
 	router.use(express.static(path.resolve(__dirname + '/../../public')));
+	router.use(express.static(path.resolve(grapesPath, './dist')));
 
 	return router;
 };

--- a/fields/types/page/PageColumn.js
+++ b/fields/types/page/PageColumn.js
@@ -1,0 +1,8 @@
+/*
+* @Author: django-wong
+* @Date:   2018-09-29 00:23:40
+* @Last Modified by:   django-wong
+* @Last Modified time: 2018-09-29 00:25:14
+*/
+
+module.exports = require('../text/TextColumn');

--- a/fields/types/page/PageField.js
+++ b/fields/types/page/PageField.js
@@ -1,0 +1,87 @@
+/*
+* @Author: django-wong
+* @Date:   2018-09-29 00:23:58
+* @Last Modified by:   django-wong
+* @Last Modified time: 2018-09-29 02:28:33
+*/
+
+import Field from '../Field';
+import React from 'react';
+import GrapesJs from 'grapesjs';
+import evalDependsOn from '../../utils/evalDependsOn';
+import { FormInput } from '../../../admin/client/App/elemental';
+
+
+var lastId = 0;
+
+function getId () {
+	return 'keystone-pages-' + lastId++;
+}
+
+module.exports = Field.create({
+
+	displayName: 'PageField',
+	statics: {
+		type: 'Page'
+	},
+
+	getInitialState () {
+		return {
+			id: getId()
+		};
+	},
+
+	componentDidMount () {
+		this.initGrapesJs();
+	},
+
+	initGrapesJs () {
+		var self = this;
+		var opts = this.getOptions();
+		this.editor = GrapesJs.init(opts);
+		this.initButtons();
+		window.editor = this.editor;
+	},
+
+	initButtons () {
+		var editor = this.editor;
+		editor.Panels.addButton('options', {
+			id: 'button-save',
+			className: 'fa fa-save',
+			command: function () {
+				console.info(editor.getHtml());
+			}
+		});
+	},
+
+	getOptions () {
+		var opts = {
+			container: '#' + this.state.id,
+			fromElement: true,
+			width: this.props.width,
+			height: this.props.height
+		};
+		return opts;
+	},
+
+	renderField () {
+		var style = {
+			height: this.props.height,
+			width: this.props.width
+		};
+		return (
+			<div id={this.state.id} style={style}>
+				<p>Hello World</p>
+			</div>
+		);
+	},
+
+	renderValue () {
+		return (
+			<FormInput multiline noedit>
+				{this.props.value}
+			</FormInput>
+		)
+	}
+
+});

--- a/fields/types/page/PageFilter.js
+++ b/fields/types/page/PageFilter.js
@@ -1,0 +1,8 @@
+/*
+* @Author: django-wong
+* @Date:   2018-09-29 00:24:12
+* @Last Modified by:   django-wong
+* @Last Modified time: 2018-09-29 00:31:39
+*/
+
+module.exports = require('../text/TextFilter');

--- a/fields/types/page/PageType.js
+++ b/fields/types/page/PageType.js
@@ -1,0 +1,36 @@
+/*
+* @Author: django-wong
+* @Date:   2018-09-29 00:24:21
+* @Last Modified by:   django-wong
+* @Last Modified time: 2018-09-29 01:36:31
+*/
+
+var FieldType = require('../Type');
+var TextType = require('../text/TextType');
+var util = require('util');
+
+/**
+ * PAGE FieldType Constructor
+ * @extends    Field
+ * @api        public
+ */
+function page (list, path, options) {
+	this._nativeType = String;
+	this._defaultSize = 'full';
+	this.height = options.height || '300px';
+	this.width = options.width || '100%';
+	this._properties = ['height', 'width'];
+	page.super_.call(this, list, path, options);
+}
+
+page.properName = 'Page';
+util.inherits(page, FieldType);
+
+page.prototype.validateInput = TextType.prototype.validateInput;
+page.prototype.validateRequiredInput = TextType.prototype.validateRequiredInput;
+
+/* Inherit from TextType prototype */
+page.prototype.addFilterToQuery = TextType.prototype.addFilterToQuery;
+
+/* Export Field Type */
+module.exports = page;

--- a/fields/types/page/Readme.md
+++ b/fields/types/page/Readme.md
@@ -1,0 +1,19 @@
+# Page Field
+
+Stores a `String` in the model.
+Displayed as a [GrapesJs](https://grapesjs.com) editor in the Admin UI.
+
+## Example
+
+```js
+{ type: Types.Page }
+```
+
+## Options
+
+* `width` `String`
+
+The editor width in the Admin UI. see [width](https://developer.mozilla.org/en-US/docs/Web/CSS/width).
+
+* `height` `String`
+The editor height in the Admin UI. see [height](https://developer.mozilla.org/en-US/docs/Web/CSS/height).

--- a/lib/fieldTypes.js
+++ b/lib/fieldTypes.js
@@ -13,6 +13,7 @@ var fields = {
 	get File () { return require('../fields/types/file/FileType'); },
 	get GeoPoint () { return require('../fields/types/geopoint/GeoPointType'); },
 	get Html () { return require('../fields/types/html/HtmlType'); },
+	get Page () { return require('../fields/types/page/PageType'); },
 	get Key () { return require('../fields/types/key/KeyType'); },
 	get LocalFile () { return require('../fields/types/localfile/LocalFileType'); },
 	get LocalFiles () { return require('../fields/types/localfiles/LocalFilesType'); },

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "expression-match": "^0.0.17",
     "fs-extra": "^1.0.0",
     "glamor": "^2.20.25",
+    "grapesjs": "^0.14.33",
     "grappling-hook": "^3.0.0",
     "i": "^0.3.5",
     "kerberos": "^1.0.0",


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes
Integrate [GrapesJS](https://grapesjs.com/) and add new _Page_ type.
This is just demo version that said it will not save any data.

## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [x] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

