### PR TITLE
fix upload file has no extension name

### DIFF
--- a/lib/storage/adapters/fs/index.js
+++ b/lib/storage/adapters/fs/index.js
@@ -94,7 +94,7 @@ FSAdapter.prototype.uploadFile = function (file, callback) {
 	var options = this.options;
 	this.getFilename(file, function (err, filename) {
 		if (err) return callback(err);
-		filename = sanitize(filename);
+		filename = sanitize(filename) + path.parse(file.originalname).ext;
 		debug('Uploading file with filename: %s', filename);
 		var uploadPath = path.resolve(options.path, filename);
 		var fsOptions = {};


### PR DESCRIPTION
<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes


## Related issues (if any)
fix upload file has no extension name

## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

